### PR TITLE
Race conditions when running multiple threads

### DIFF
--- a/jodconverter-core/src/test/java/org/artofsolving/jodconverter/StressTest.java
+++ b/jodconverter-core/src/test/java/org/artofsolving/jodconverter/StressTest.java
@@ -1,0 +1,127 @@
+//
+// JODConverter - Java OpenDocument Converter
+// Copyright 2004-2011 Mirko Nasato and contributors
+//
+// JODConverter is free software: you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// JODConverter is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General
+// Public License along with JODConverter.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+package org.artofsolving.jodconverter;
+
+import java.io.File;
+
+import org.artofsolving.jodconverter.document.DocumentFormat;
+import org.artofsolving.jodconverter.document.DocumentFormatRegistry;
+import org.artofsolving.jodconverter.office.DefaultOfficeManagerConfiguration;
+import org.artofsolving.jodconverter.office.OfficeManager;
+import org.testng.annotations.Test;
+
+@Test(groups="functional")
+public class StressTest {
+	
+	private static final int MAX_CONVERSIONS = 1024;
+	private static final int MAX_RUNNING_THREADS = 128;
+	private static final int MAX_TASKS_PER_PROCESS = 10;
+	
+	private static final String INPUT_EXTENSION = "rtf";
+	private static final String OUTPUT_EXTENSION = "pdf";
+
+    public void runParallelConversions() throws Exception
+    {
+    	// Configure the office manager in a way that maximizes possible race conditions.
+    	DefaultOfficeManagerConfiguration configuration = new DefaultOfficeManagerConfiguration();
+    	configuration.setPortNumbers(2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009);
+    	configuration.setMaxTasksPerProcess(MAX_TASKS_PER_PROCESS);
+    	
+        OfficeManager officeManager = configuration.buildOfficeManager();
+        OfficeDocumentConverter converter = new OfficeDocumentConverter(officeManager);
+        DocumentFormatRegistry formatRegistry = converter.getFormatRegistry();
+        
+        
+        officeManager.start();
+        try {
+            File inputFile = new File("src/test/resources/documents/test." + INPUT_EXTENSION);
+            
+            Thread[] threads = new Thread[MAX_RUNNING_THREADS];
+            
+            boolean first = true;
+            int t = 0;
+            
+		    for (int i = 0; i < MAX_CONVERSIONS; i++) {
+                DocumentFormat inputFormat = formatRegistry.getFormatByExtension(INPUT_EXTENSION);
+                DocumentFormat outputFormat = formatRegistry.getFormatByExtension(OUTPUT_EXTENSION);
+                
+                File outputFile = File.createTempFile("test", "." + outputFormat.getExtension());
+                outputFile.deleteOnExit();
+                
+                // Converts the first document without threads to ensure everything is OK. 
+                if (first) {
+                	converter.convert(inputFile, outputFile, outputFormat);
+                	first = false;
+                }
+                
+                System.out.println("Creating thread " + t + "...");
+                Runner r = new Runner(inputFile, outputFile, inputFormat, outputFormat, converter);
+                threads[t] = new Thread(r);
+                threads[t++].start();
+                
+                if (t == MAX_RUNNING_THREADS) {
+                	for (int j = 0; j < t; j++) {
+                		threads[j].join();
+                	}
+                	t = 0;
+                }
+		    }
+		    
+		    // Wait for remaining threads.
+		    for (int j = 0; j < t; j++) {
+		    	threads[j].join();
+		    }
+	    
+	    
+        }
+        finally {
+            officeManager.stop();
+        }
+    }
+    
+    public class Runner implements Runnable {
+
+    	public Runner(File inputFile, File outputFile, DocumentFormat inputFormat, DocumentFormat outputFormat,
+    			OfficeDocumentConverter converter) {
+    		super();
+    		this.inputFile = inputFile;
+    		this.outputFile = outputFile;
+    		this.inputFormat = inputFormat;
+    		this.outputFormat = outputFormat;
+    		this.converter = converter;
+    	}
+
+    	File inputFile, outputFile;
+
+    	DocumentFormat inputFormat, outputFormat;
+
+    	OfficeDocumentConverter converter;
+
+    	public void run() {
+    		try {
+    			System.out.printf("-- converting %s to %s... ", inputFormat.getExtension(), outputFormat.getExtension());
+    			converter.convert(inputFile, outputFile, outputFormat);
+    			System.out.printf("done.\n");
+    		}
+    		catch (Exception e) {
+    			e.printStackTrace();
+    		}
+    	}
+    }
+}


### PR DESCRIPTION
JOD Converter still has some race conditions that trigger when several threads request conversions at the same time.

This stress test helps to debug and identify such problems. It creates MAX_RUNNING_THREADS threads to concurrently request up to MAX_CONVERSIONS conversions from RTF to PDF. The threads races for 8 converters, which are restarted after MAX_TASKS_PER_PROCESS conversions each.

After some time running the test, the exception below occurs:

```
org.artofsolving.jodconverter.office.OfficeException: failed to restart
    at org.artofsolving.jodconverter.office.ManagedOfficeProcess.restartAndWait(ManagedOfficeProcess.java:99)
    at org.artofsolving.jodconverter.office.PooledOfficeManager$2.run(PooledOfficeManager.java:89)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
    at java.util.concurrent.FutureTask.run(FutureTask.java:262)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:745)
Caused by: java.util.concurrent.ExecutionException: org.artofsolving.jodconverter.office.OfficeException: could not establish connection
    at java.util.concurrent.FutureTask.report(FutureTask.java:122)
    at java.util.concurrent.FutureTask.get(FutureTask.java:188)
    at org.artofsolving.jodconverter.office.ManagedOfficeProcess.restartAndWait(ManagedOfficeProcess.java:97)
    ... 6 more
Caused by: org.artofsolving.jodconverter.office.OfficeException: could not establish connection
    at org.artofsolving.jodconverter.office.ManagedOfficeProcess.doStartProcessAndConnect(ManagedOfficeProcess.java:162)
    at org.artofsolving.jodconverter.office.ManagedOfficeProcess.access$000(ManagedOfficeProcess.java:25)
    at org.artofsolving.jodconverter.office.ManagedOfficeProcess$3.run(ManagedOfficeProcess.java:93)
    ... 5 more
Caused by: java.lang.IllegalStateException: process with acceptString 'socket,host=127.0.0.1,port=2006' started but its pid could not be found
    at org.artofsolving.jodconverter.office.OfficeProcess.start(OfficeProcess.java:103)
    at org.artofsolving.jodconverter.office.OfficeProcess.start(OfficeProcess.java:64)
    at org.artofsolving.jodconverter.office.ManagedOfficeProcess.doStartProcessAndConnect(ManagedOfficeProcess.java:134)
    ... 7 more
```

I'm crossposting this pull request for nuxeo and xwiki repositories in the hope of someone helping fix the bug.
